### PR TITLE
feat: add Admin Mode auth and protect registration actions

### DIFF
--- a/src/admin_users.json
+++ b/src/admin_users.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher1",
+      "password": "changeme123"
+    },
+    {
+      "username": "teacher2",
+      "password": "changeme456"
+    }
+  ]
+}

--- a/src/app.py
+++ b/src/app.py
@@ -5,19 +5,44 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Cookie, Depends, FastAPI, HTTPException, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+from typing import Optional
 import os
+import json
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
 
+SESSION_COOKIE_NAME = "admin_session"
+admin_sessions = {}
+
 # Mount the static files directory
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+
+def load_admin_users():
+    users_file = current_dir / "admin_users.json"
+    if not users_file.exists():
+        return {}
+
+    with open(users_file, "r", encoding="utf-8") as file:
+        data = json.load(file)
+
+    return {
+        user["username"]: user["password"]
+        for user in data.get("teachers", [])
+        if "username" in user and "password" in user
+    }
+
+
+admin_users = load_admin_users()
 
 # In-memory activity database
 activities = {
@@ -78,6 +103,18 @@ activities = {
 }
 
 
+class AdminCredentials(BaseModel):
+    username: str
+    password: str
+
+
+def require_admin(session_token: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE_NAME)):
+    username = admin_sessions.get(session_token)
+    if not username:
+        raise HTTPException(status_code=401, detail="Admin login required")
+    return username
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -88,8 +125,43 @@ def get_activities():
     return activities
 
 
+@app.get("/admin/session")
+def get_admin_session(session_token: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE_NAME)):
+    username = admin_sessions.get(session_token)
+    return {
+        "authenticated": bool(username),
+        "username": username
+    }
+
+
+@app.post("/admin/login")
+def admin_login(credentials: AdminCredentials, response: Response):
+    expected_password = admin_users.get(credentials.username)
+    if expected_password != credentials.password:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    session_token = secrets.token_urlsafe(32)
+    admin_sessions[session_token] = credentials.username
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=session_token,
+        httponly=True,
+        samesite="lax",
+        max_age=60 * 60 * 8,
+    )
+    return {"message": "Logged in successfully", "username": credentials.username}
+
+
+@app.post("/admin/logout")
+def admin_logout(response: Response, session_token: Optional[str] = Cookie(default=None, alias=SESSION_COOKIE_NAME)):
+    if session_token in admin_sessions:
+        del admin_sessions[session_token]
+    response.delete_cookie(SESSION_COOKIE_NAME)
+    return {"message": "Logged out"}
+
+
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, admin: str = Depends(require_admin)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +183,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, admin: str = Depends(require_admin)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,52 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const signupLockedMessage = document.getElementById("signup-locked-message");
+  const adminMenuBtn = document.getElementById("admin-menu-btn");
+  const adminModal = document.getElementById("admin-modal");
+  const modalCloseBtn = document.getElementById("modal-close-btn");
+  const adminLoginForm = document.getElementById("admin-login-form");
+  const adminSessionInfo = document.getElementById("admin-session-info");
+  const adminWelcomeText = document.getElementById("admin-welcome-text");
+  const logoutBtn = document.getElementById("logout-btn");
+
+  let adminUsername = null;
+
+  function setAdminUi() {
+    const isAdmin = Boolean(adminUsername);
+    signupForm.classList.toggle("hidden", !isAdmin);
+    signupLockedMessage.classList.toggle("hidden", isAdmin);
+    adminSessionInfo.classList.toggle("hidden", !isAdmin);
+    adminLoginForm.classList.toggle("hidden", isAdmin);
+    adminMenuBtn.textContent = isAdmin ? "✅" : "👤";
+
+    if (isAdmin) {
+      adminWelcomeText.textContent = `Logged in as ${adminUsername}`;
+    }
+  }
+
+  async function loadAdminSession() {
+    try {
+      const response = await fetch("/admin/session");
+      const result = await response.json();
+      adminUsername = result.authenticated ? result.username : null;
+      setAdminUi();
+    } catch (error) {
+      adminUsername = null;
+      setAdminUi();
+      console.error("Error loading admin session:", error);
+    }
+  }
+
+  function showMessage(text, type) {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +58,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +77,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        adminUsername
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -57,9 +108,11 @@ document.addEventListener("DOMContentLoaded", () => {
       });
 
       // Add event listeners to delete buttons
-      document.querySelectorAll(".delete-btn").forEach((button) => {
-        button.addEventListener("click", handleUnregister);
-      });
+      if (adminUsername) {
+        document.querySelectorAll(".delete-btn").forEach((button) => {
+          button.addEventListener("click", handleUnregister);
+        });
+      }
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -86,26 +139,15 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -130,31 +172,87 @@ document.addEventListener("DOMContentLoaded", () => {
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  adminMenuBtn.addEventListener("click", () => {
+    adminModal.classList.remove("hidden");
+  });
+
+  modalCloseBtn.addEventListener("click", () => {
+    adminModal.classList.add("hidden");
+  });
+
+  adminModal.addEventListener("click", (event) => {
+    if (event.target === adminModal) {
+      adminModal.classList.add("hidden");
+    }
+  });
+
+  adminLoginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("admin-username").value;
+    const password = document.getElementById("admin-password").value;
+
+    try {
+      const response = await fetch("/admin/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (response.ok) {
+        adminUsername = result.username;
+        setAdminUi();
+        fetchActivities();
+        adminLoginForm.reset();
+        adminModal.classList.add("hidden");
+        showMessage("Admin login successful", "success");
+      } else {
+        showMessage(result.detail || "Login failed", "error");
+      }
+    } catch (error) {
+      showMessage("Login failed", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      const response = await fetch("/admin/logout", { method: "POST" });
+      const result = await response.json();
+
+      if (response.ok) {
+        adminUsername = null;
+        setAdminUi();
+        fetchActivities();
+        adminModal.classList.add("hidden");
+        showMessage(result.message, "success");
+      } else {
+        showMessage(result.detail || "Logout failed", "error");
+      }
+    } catch (error) {
+      showMessage("Logout failed", "error");
+      console.error("Error logging out:", error);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  loadAdminSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,9 @@
   </head>
   <body>
     <header>
+      <button id="admin-menu-btn" class="admin-menu-btn" aria-label="Open admin menu">
+        👤
+      </button>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>
@@ -23,6 +26,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="signup-locked-message" class="info hidden">
+          Only logged-in teachers can register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -44,6 +50,30 @@
     <footer>
       <p>&copy; 2026 Mergington High School</p>
     </footer>
+
+    <div id="admin-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="admin-modal-title">
+      <div class="modal-content">
+        <button id="modal-close-btn" class="modal-close-btn" aria-label="Close">x</button>
+        <h3 id="admin-modal-title">Admin Access</h3>
+
+        <div id="admin-session-info" class="hidden">
+          <p id="admin-welcome-text"></p>
+          <button id="logout-btn" type="button">Log Out</button>
+        </div>
+
+        <form id="admin-login-form">
+          <div class="form-group">
+            <label for="admin-username">Username:</label>
+            <input type="text" id="admin-username" required />
+          </div>
+          <div class="form-group">
+            <label for="admin-password">Password:</label>
+            <input type="password" id="admin-password" required />
+          </div>
+          <button type="submit">Log In</button>
+        </form>
+      </div>
+    </div>
 
     <script src="app.js"></script>
   </body>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,32 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.admin-menu-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background-color: rgba(255, 255, 255, 0.15);
+  font-size: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.admin-menu-btn:hover {
+  background-color: rgba(255, 255, 255, 0.25);
 }
 
 header h1 {
@@ -190,6 +210,38 @@ button:hover {
 
 .hidden {
   display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
+}
+
+.modal-content {
+  width: 100%;
+  max-width: 420px;
+  background-color: white;
+  border-radius: 8px;
+  padding: 20px;
+  position: relative;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+}
+
+.modal-close-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  font-size: 14px;
+  padding: 0;
 }
 
 footer {


### PR DESCRIPTION
## Summary
Implements issue #5 (Admin Mode) by adding teacher authentication and protecting enrollment actions.

## Changes
- add admin login/logout/session endpoints in backend
- use HTTP-only session cookie for authenticated admin session
- require admin auth for signup and unregister endpoints
- add teacher credential store in `src/admin_users.json`
- add frontend admin user button + login modal
- hide signup/unregister actions for non-admin users while keeping participant visibility

## Notes
- default sample credentials are included for local testing in `src/admin_users.json`
- this PR intentionally leaves unrelated untracked local file `.vscode/mcp.json` out of commit scope

## Validation
- static/py files report no diagnostics in editor
- branch pushed and ready for review